### PR TITLE
feat: add support for custom modules

### DIFF
--- a/R/run_app.R
+++ b/R/run_app.R
@@ -10,12 +10,24 @@ NULL
 #' @param config_file The name of the yaml configuration file
 #' @param data_folder Optional directory prefix for data files. 
 #'  Enables using the same configuration file for different versions of data files.
+#' @param custom_modules Optional list of available custom modules. See the 'Details' section.
 #' @param ... Further optional arguments.
+#'
+#' @details `custom_modules` should contain a list of names for user-defined
+#' modules that are loaded in the environment before calling run_app. Each 
+#' module should be accompanied by the corresponding mod_moduleName_ui, 
+#' mod_moduleName_server moduleName_config functions. These functions could be 
+#' placed in a custom_modules.R file, for example, and loaded using `source`. 
+#' The package will then parse the configuration file, and if it contains one of
+#' the custom module names, it will call the module configuration parsing 
+#' function and add it to the interface. See `vignette("custom_modules")` for a 
+#' complete example.
 #'
 #' @export
 run_app <- function(
   config_file,
   data_folder = "",
+  custom_modules = NULL,
   ...
 ) {
     app <- shinyApp(
@@ -24,7 +36,10 @@ run_app <- function(
     )
     
     app$appOptions$loaded_opts <-
-      list(config = parseConfig(config_file, data_folder), ...)
+      list(config = parseConfig(config_file,
+                                data_folder,
+                                custom_modules = custom_modules),
+           ...)
     
     app
 }
@@ -49,6 +64,7 @@ run_module <- function(
   module_name,
   config_file,
   data_folder = "",
+  custom_modules = NULL,
   ...
 ) {
     app <- shiny::shinyApp(
@@ -57,7 +73,11 @@ run_module <- function(
     )
     app$appOptions$loaded_opts <-
       list(module_name = module_name,
-           config = parseConfig(config_file, data_folder, module_name), ...)
+           config = parseConfig(config_file,
+                                data_folder,
+                                test_module = module_name,
+                                custom_modules = custom_modules),
+            ...)
     print(app)
 }
 

--- a/man/run_app.Rd
+++ b/man/run_app.Rd
@@ -4,7 +4,7 @@
 \alias{run_app}
 \title{Run the Shiny Application}
 \usage{
-run_app(config_file, data_folder = "", ...)
+run_app(config_file, data_folder = "", custom_modules = NULL, ...)
 }
 \arguments{
 \item{config_file}{The name of the yaml configuration file}
@@ -12,8 +12,21 @@ run_app(config_file, data_folder = "", ...)
 \item{data_folder}{Optional directory prefix for data files.
 Enables using the same configuration file for different versions of data files.}
 
+\item{custom_modules}{Optional list of available custom modules. See the 'Details' section.}
+
 \item{...}{Further optional arguments.}
 }
 \description{
 Run the Shiny Application
+}
+\details{
+\code{custom_modules} should contain a list of names for user-defined
+modules that are loaded in the environment before calling run_app. Each
+module should be accompanied by the corresponding mod_moduleName_ui,
+mod_moduleName_server moduleName_config functions. These functions could be
+placed in a custom_modules.R file, for example, and loaded using \code{source}.
+The package will then parse the configuration file, and if it contains one of
+the custom module names, it will call the module configuration parsing
+function and add it to the interface. See \code{vignette("custom_modules")} for a
+complete example.
 }


### PR DESCRIPTION
Resolves #44 through a custom_modules parameter to run_app that receives a list of module names that should be defined by the user in their environment.